### PR TITLE
feat: prepare for deprecation of jQueryObject and id selector as container option (close #18)

### DIFF
--- a/src/js/pagination.js
+++ b/src/js/pagination.js
@@ -22,7 +22,10 @@ var defaultOption = {
 /**
  * Pagination class
  * @class Pagination
- * @param {string|HTMLElement|jQueryObject} container - Container element or id selector
+ * @param {string|HTMLElement|jQueryObject} container - Container element or selector.
+ * In case of a string, it is considered as an id selector and find the element by id.
+ * If there is no element, it is considered as a selector and find the element by querySelector().
+ * Passing jQueryObject and considering an id selector at first will be deprecated in v4.0.0.
  * @param {object} options - Option object
  *     @param {number} [options.totalItems=10] Total item count
  *     @param {number} [options.itemsPerPage=10] Item count per page

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -115,7 +115,7 @@ var View = defineClass(
      */
     _setRootElement: function(container) {
       if (isString(container)) {
-        container = document.getElementById(container);
+        container = document.getElementById(container) || document.querySelector(container);
       } else if (container.jquery) {
         container = container[0];
       }

--- a/test/pagination.spec.js
+++ b/test/pagination.spec.js
@@ -6,6 +6,7 @@ var util = require('@/util');
 function createElement(tagName, id) {
   var elem = document.createElement(tagName);
   elem.id = id;
+  document.body.appendChild(elem);
 
   return elem;
 }
@@ -19,9 +20,9 @@ describe('Pagination', function() {
     element2 = createElement('div', 'pagination2');
     element3 = createElement('div', 'pagination3');
 
-    pagination1 = new Pagination(element1);
+    pagination1 = new Pagination('pagination1');
 
-    pagination2 = new Pagination(element2, {
+    pagination2 = new Pagination('#pagination2', {
       totalItems: 500,
       itemsPerPage: 10,
       visiblePages: 11,
@@ -39,6 +40,12 @@ describe('Pagination', function() {
         currentPage: '<span class=page>{{page}}</span>'
       }
     });
+  });
+
+  afterEach(function() {
+    document.body.removeChild(element1);
+    document.body.removeChild(element2);
+    document.body.removeChild(element3);
   });
 
   describe('usageStatistics', function() {

--- a/test/view.spec.js
+++ b/test/view.spec.js
@@ -5,6 +5,7 @@ var View = require('@/view.js');
 function createElement(tagName, id) {
   var elem = document.createElement(tagName);
   elem.id = id;
+  document.body.appendChild(elem);
 
   return elem;
 }
@@ -27,7 +28,7 @@ describe('View', function() {
     element1 = createElement('div', 'pagination1');
     element2 = createElement('div', 'pagination2');
 
-    pagination1 = new View(element1, {
+    pagination1 = new View('pagination1', {
       firstItemClassName: 'left-child',
       lastItemClassName: 'right-child'
     });
@@ -48,6 +49,11 @@ describe('View', function() {
     });
 
     pagination2.update(viewData);
+  });
+
+  afterEach(function() {
+    document.body.removeChild(element1);
+    document.body.removeChild(element2);
   });
 
   describe('basic opitons - ', function() {


### PR DESCRIPTION
* [x] Notice that passing the jQueryObject as the container will be deprecated in v4.0
* [x] Notice that considering as id selector when the container is a string will be deprecated in v4.0
* [x] Also use `querySelector` when the container is a string
* ref: https://github.com/nhn/tui.pagination/pull/16#discussion_r358533095